### PR TITLE
Replace GH_TOKEN with JF_BOT_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,11 +69,11 @@ jobs:
       run: npm publish --tag ${{ matrix.version }} --access public
       working-directory: ./${{ matrix.version }}
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.ORG_PAT }}
 
     - name: Set as latest in GitHub Packages
       if: ${{ matrix.version == 'stable' }}
       run: npm dist-tag add @jellyfin/client-axios@${{ steps.version.outputs.number }} latest
       working-directory: ./${{ matrix.version }}
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.ORG_PAT }}


### PR DESCRIPTION
``GH_TOKEN`` seems to be used internally by GitHub and it's making some actions we're using in some repos fail ([Source](https://github.com/alex-page/github-project-automation-plus/issues/39))

*(PRs made from users of the org are always successful, but PRs that aren't don't work, like Dependabot PRs. This can be checked by looking at the history of server repos and Jellyfin Vue)*

The org-wide secret should be renamed to something else to avoid confusion and further replacements or messes in GH's side. This PR replaces ``GH_TOKEN`` with ``JF_BOT_TOKEN``, which should be pretty generic.