### PR TITLE
Disable fail-fast and use npm cache

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,18 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: npm
     directory: '/stable'
     schedule:
-      interval: daily
+      interval: weekly
       time: '00:00'
     open-pull-requests-limit: 10
 
   - package-ecosystem: npm
     directory: '/unstable'
     schedule:
-      interval: daily
+      interval: weekly
       time: '00:00'
     open-pull-requests-limit: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        version: 
+        version:
           - stable
           - unstable
 
@@ -19,23 +20,11 @@ jobs:
         ref: 'master'
 
     - name: Setup node environment for NPMJS
-      uses: actions/setup-node@v2.2.0
+      uses: actions/setup-node@v2.4.0
       with:
         node-version: 14
+        cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
-
-    - name: Get npm cache directory path
-      id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Cache node_modules
-      uses: actions/cache@v2.1.6
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/${{ matrix.version }}/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-
 
     - name: Get package version
       id: version
@@ -60,9 +49,10 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Setup node environment for GitHub Package Registry
-      uses: actions/setup-node@v2.2.0
+      uses: actions/setup-node@v2.4.0
       with:
         node-version: 14
+        cache: 'npm'
         registry-url: 'https://npm.pkg.github.com'
 
     - name: Publish to GitHub Package registry

--- a/.github/workflows/stable-generation.yml
+++ b/.github/workflows/stable-generation.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         ref: 'master'
 
-    - name: Generate	    
+    - name: Generate
       uses: docker://openapitools/openapi-generator-cli:latest-release
       env:
         TS_POST_PROCESS_FILE: true
@@ -47,24 +47,10 @@ jobs:
 
     - name: Setup node environment
       if: ${{ steps.diff.outputs.count }} > 0
-      uses: actions/setup-node@v2.2.0
+      uses: actions/setup-node@v2.4.0
       with:
         node-version: 14
-
-    - name: Get npm cache directory path
-      if: ${{ steps.diff.outputs.count }} > 0
-      id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Cache node_modules
-      if: ${{ steps.diff.outputs.count }} > 0
-      uses: actions/cache@v2.1.6
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/stable/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-
+        cache: 'npm'
 
     - name: Install dependencies
       if: ${{ steps.diff.outputs.count }} > 0

--- a/.github/workflows/unstable-generation.yml
+++ b/.github/workflows/unstable-generation.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         ref: 'master'
 
-    - name: Generate	    
+    - name: Generate
       uses: docker://openapitools/openapi-generator-cli:latest-release
       env:
         TS_POST_PROCESS_FILE: true
@@ -61,24 +61,10 @@ jobs:
 
     - name: Setup node environment
       if: ${{ steps.diff.outputs.count }} > 0
-      uses: actions/setup-node@v2.2.0
+      uses: actions/setup-node@v2.4.0
       with:
         node-version: 14
-
-    - name: Get npm cache directory path
-      if: ${{ steps.diff.outputs.count }} > 0
-      id: npm-cache-dir-path
-      run: echo "::set-output name=dir::$(npm config get cache)"
-
-    - name: Cache node_modules
-      if: ${{ steps.diff.outputs.count }} > 0
-      uses: actions/cache@v2.1.6
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-npm-${{ hashFiles('**/unstable/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-npm-
+        cache: 'npm'
 
     - name: Install dependencies
       if: ${{ steps.diff.outputs.count }} > 0


### PR DESCRIPTION
This allows the repository to publish the stable API client when it fails to publish the unstable one for any reason.

Currently, whenever one of the two runs defined by the matrix in the publish workflow would fail, the other one would be cancelled. So currently, the repository does this:

* Publish unstable to NPM
* Publish unstable to GHCR (This fails)
* Cancel the entire workflow

We might never reach a point where we are publishing stable to NPM. Even worse: we might be cancelling a publish in progress, which may lead to weird stuff happening.

With this, the non-failing pipeline will continue even if the other one in the matrix fails.

This also moved to using the `setup-node` action's NPM cache, which is now recommended over the older caching mechanism.

I also removed some trailing spaces in all the workflows.