### PR TITLE
Remove allOf objects before generating client

### DIFF
--- a/.github/workflows/stable-generation.yml
+++ b/.github/workflows/stable-generation.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Get OpenApi version
       if: ${{ steps.diff.outputs.count }} > 0
       id: version
-      run: echo "::set-output name=number::$(curl -s openapi.json | jq '.info.version')"
+      run: echo "::set-output name=number::$(cat openapi.json | jq '.info.version')"
 
     - name: Set version in package.json
       if: ${{ steps.diff.outputs.count }} > 0

--- a/.github/workflows/stable-generation.yml
+++ b/.github/workflows/stable-generation.yml
@@ -12,6 +12,12 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         ref: 'master'
+    
+    - name: Download OpenAPI file
+      run: curl -s https://api.jellyfin.org/openapi/jellyfin-openapi-stable.json > openapi.json
+    
+    - name: Modify the schema
+      run: node scripts/modifySchema.mjs openapi.json
 
     - name: Generate	    
       uses: docker://openapitools/openapi-generator-cli:latest-release
@@ -19,7 +25,7 @@ jobs:
         TS_POST_PROCESS_FILE: true
       with:
         args: >-
-          generate -i https://api.jellyfin.org/openapi/jellyfin-openapi-stable.json
+          generate -i /github/workspace/openapi.json
           -g typescript-axios --additional-properties=npmName=@jellyfin/client-axios
           --additional-properties=npmRepository=https://www.npmjs.com/package/@jellyfin/client-axios
           --additional-properties=supportsES6=true
@@ -37,7 +43,7 @@ jobs:
     - name: Get OpenApi version
       if: ${{ steps.diff.outputs.count }} > 0
       id: version
-      run: echo "::set-output name=number::$(curl -s https://api.jellyfin.org/openapi/jellyfin-openapi-stable.json | jq '.info.version')"
+      run: echo "::set-output name=number::$(curl -s openapi.json | jq '.info.version')"
 
     - name: Set version in package.json
       if: ${{ steps.diff.outputs.count }} > 0

--- a/.github/workflows/unstable-generation.yml
+++ b/.github/workflows/unstable-generation.yml
@@ -13,6 +13,12 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         ref: 'master'
+    
+    - name: Download OpenAPI file
+      run: curl -s https://api.jellyfin.org/openapi/jellyfin-openapi-unstable.json > openapi.json
+    
+    - name: Modify the schema
+      run: node scripts/modifySchema.mjs openapi.json
 
     - name: Generate	    
       uses: docker://openapitools/openapi-generator-cli:latest-release
@@ -20,7 +26,7 @@ jobs:
         TS_POST_PROCESS_FILE: true
       with:
         args: >-
-          generate -i https://api.jellyfin.org/openapi/jellyfin-openapi-unstable.json
+          generate -i /github/workspace/openapi.json
           -g typescript-axios --additional-properties=npmName=@jellyfin/client-axios
           --additional-properties=npmRepository=https://www.npmjs.com/package/@jellyfin/client-axios
           --additional-properties=supportsES6=true
@@ -45,7 +51,7 @@ jobs:
       if: ${{ steps.diff.outputs.count }} > 0
       id: apiversion
       run: |
-        SERVER_VERSION="$(curl -s https://api.jellyfin.org/openapi/jellyfin-openapi-unstable.json | jq '.info.version')"
+        SERVER_VERSION="$(curl -s openapi.json | jq '.info.version')"
         echo "::set-output name=number::$(echo ${SERVER_VERSION::-1})"
 
     - name: Create new version string

--- a/.github/workflows/unstable-generation.yml
+++ b/.github/workflows/unstable-generation.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Modify the schema
       run: node scripts/modifySchema.mjs openapi.json
 
-    - name: Generate	    
+    - name: Generate
       uses: docker://openapitools/openapi-generator-cli:latest-release
       env:
         TS_POST_PROCESS_FILE: true
@@ -51,7 +51,7 @@ jobs:
       if: ${{ steps.diff.outputs.count }} > 0
       id: apiversion
       run: |
-        SERVER_VERSION="$(curl -s openapi.json | jq '.info.version')"
+        SERVER_VERSION="$(cat openapi.json | jq '.info.version')"
         echo "::set-output name=number::$(echo ${SERVER_VERSION::-1})"
 
     - name: Create new version string

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ wwwroot/*.js
 node_modules
 typings
 dist
+/openapi.json

--- a/scripts/modifySchema.mjs
+++ b/scripts/modifySchema.mjs
@@ -1,0 +1,16 @@
+import fs from 'fs/promises';
+
+(async (file) => {
+	let txt = await fs.readFile(file);
+	const json = JSON.parse(txt, (_, value) => {
+		// Remove all "allOf" instances, this removes nullability/descriptions
+		if (typeof value === 'object' && 'allOf' in value && value.allOf.length === 1) {
+			return value.allOf[0];
+		}
+		
+		return value;
+	});
+
+	txt = JSON.stringify(json);
+	await fs.writeFile(file, txt);
+})(process.argv[2]);


### PR DESCRIPTION
Changed the build script to:

- Download the openapi.json locally
- Modify it with a script to remove the `allOf {}` objects to workaround an openapi-generator issue
- Generate with the local file

I did not test the workflow, the script works as expected.