### PR TITLE
Bring back dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: npm
+    directory: '/stable'
+    schedule:
+      interval: weekly
+      time: '00:00'
+
+  - package-ecosystem: npm
+    directory: '/unstable'
+    schedule:
+      interval: weekly
+      time: '00:00'


### PR DESCRIPTION
This PRs brings back dependabot, which was removed by https://github.com/jellyfin/jellyfin-client-axios/pull/110 (by mistake, I think? Kindly explain the reasoning if I'm wrong @MrTimscampi)

Dependabot handle updates for dependencies of this client (TypeScript and axios), not the client itself. Dependencies bundled by the generator [are hardcoded by OpenApi generator and not "updated" automatically by it](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/typescript-axios/package.mustache#L21). For example, the generator had no updates since April 2019 until January 2020 (to fix a major security vulnerability), which is way too much time without updates (which also included [minor security fixes, also important](https://github.com/axios/axios/releases).

package.json is also completely ignored by the generator and [it's only manipulated by CI](https://github.com/jellyfin/jellyfin-client-axios/blob/master/stable/.openapi-generator-ignore#L5). This is required so the package works properly in ES6, as the default tsconfig was also not correct.