### PR TITLE
Add propre npm versioning for unstable versions

### DIFF
--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -59,8 +59,7 @@ jobs:
       - name: (unstable) Set version in package.json
         if: ${{ steps.diff.outputs.count > 0 && matrix.version == 'unstable' }}
         run: |
-          BUILD_VERSION=$(cat openapi.json | jq '.info.version')
-          BUILD_VERSION=${BUILD_VERSION:1:-1} # Current build version
+          BUILD_VERSION=$(cat openapi.json | jq -r '.info.version')
           NPM_UNSTABLE=$(npm show @jellyfin/client-axios@unstable version) # Current unstable version on npm
           UNSTABLE_NPM_VERSION=$(echo $NPM_UNSTABLE | sed -n 's/^\(.\+\)-unstable\.\([0-9]\+\)$/\1/p' )
           UNSTABLE_NPM_SUFFIX=$(echo $NPM_UNSTABLE | sed -n 's/^\(.\+\)-unstable\.\([0-9]\+\)$/\2/p' )

--- a/.github/workflows/generation.yml
+++ b/.github/workflows/generation.yml
@@ -59,10 +59,17 @@ jobs:
       - name: (unstable) Set version in package.json
         if: ${{ steps.diff.outputs.count > 0 && matrix.version == 'unstable' }}
         run: |
-          SERVER_SHA="$(git ls-remote git://github.com/jellyfin/jellyfin.git | grep refs/heads/master | cut -f 1  | cut -c1-7)"
-          SERVER_VERSION="$(cat openapi.json | jq '.info.version')"
-          SERVER_VERSION=${SERVER_VERSION:1:-1}
-          VERSION=$(echo "$SERVER_VERSION-unstable+$SERVER_SHA")
+          BUILD_VERSION=$(cat openapi.json | jq '.info.version')
+          BUILD_VERSION=${BUILD_VERSION:1:-1} # Current build version
+          NPM_UNSTABLE=$(npm show @jellyfin/client-axios@unstable version) # Current unstable version on npm
+          UNSTABLE_NPM_VERSION=$(echo $NPM_UNSTABLE | sed -n 's/^\(.\+\)-unstable\.\([0-9]\+\)$/\1/p' )
+          UNSTABLE_NPM_SUFFIX=$(echo $NPM_UNSTABLE | sed -n 's/^\(.\+\)-unstable\.\([0-9]\+\)$/\2/p' )
+          if [[ "$BUILD_VERSION" == "$UNSTABLE_NPM_VERSION" ]]; then
+            FINAL_NPM_SUFFIX=$((UNSTABLE_NPM_SUFFIX + 1))
+          else
+            FINAL_NPM_SUFFIX=0
+          fi
+          VERSION=$BUILD_VERSION-unstable.$FINAL_NPM_SUFFIX
           echo "$(cat unstable/package.json | jq ".version = \"${VERSION}\"")" > unstable/package.json
           echo "$(cat unstable/package-lock.json | jq ".version = \"${VERSION}\"")" > unstable/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Get package version
         id: version
-        run: echo "::set-output name=number::$(echo $(cat package.json | jq '.version') | tr -d '"')"
+        run: echo "::set-output name=number::$(echo $(cat package.json | jq -r '.version'))"
         working-directory: ./${{ matrix.version }}
 
       - name: Install dependencies


### PR DESCRIPTION
So, now unstable builds should be versioned as `SERVER_VERSION-unstable.INCREMENTAL_INT` such as `10.8.0-unstable.0`, `10.8.0-unstable.1` and so on.

An example of working pipe is here: https://github.com/ThibaultNocchi/jellyfin-client-axios/runs/3631529291?check_suite_focus=true

Also, the commands are available in this bash script if you wanna try the different versions combinations:

```bash
#!/bin/bash

# BUILD_VERSION=$(cat openapi.json | jq -r '.info.version')
# NPM_UNSTABLE=$(npm show @jellyfin/client-axios@unstable version)

BUILD_VERSION=10.8.0
NPM_UNSTABLE=10.8.0-unstable.3

UNSTABLE_NPM_VERSION=$(echo $NPM_UNSTABLE | sed -n 's/^\(.\+\)-unstable\.\([0-9]\+\)$/\1/p' )
UNSTABLE_NPM_SUFFIX=$(echo $NPM_UNSTABLE | sed -n 's/^\(.\+\)-unstable\.\([0-9]\+\)$/\2/p' )

if [[ "$BUILD_VERSION" == "$UNSTABLE_NPM_VERSION" ]]; then
    FINAL_NPM_SUFFIX=$((UNSTABLE_NPM_SUFFIX + 1))
else
    FINAL_NPM_SUFFIX=0
fi

VERSION=$BUILD_VERSION-unstable.$FINAL_NPM_SUFFIX
echo $VERSION
```

There's a caveat: we lose the reference to the server commit hash on which the SDK is built against. What do you think of it?

On a sidenote, `jq` has the `-r` flag for `raw` and strips the double quotes around JSON strings when outputting them, saving us from manually doing it